### PR TITLE
Add mlir support for OneHotEncoder

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,18 +46,19 @@ rules_cc_toolchains()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 RULES_JVM_EXTERNAL_TAG = "4.2"
+
 RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
 
 http_archive(
     name = "rules_jvm_external",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
 http_archive(
     name = "com_github_nlohmann_json",
-    build_file = "//third_party:json.BUILD", # see below
+    build_file = "//third_party:json.BUILD",  # see below
     sha256 = "4cf0df69731494668bdd6460ed8cb269b68de9c19ad8c27abc24cd72605b2d5b",
     strip_prefix = "json-3.9.1",
     urls = ["https://github.com/nlohmann/json/archive/v3.9.1.tar.gz"],
@@ -65,6 +66,7 @@ http_archive(
 
 # io_bazel_rules_scala defines scala version.
 rules_scala_version = "e7a948ad1948058a7a5ddfbd9d1629d6db839933"
+
 http_archive(
     name = "io_bazel_rules_scala",
     sha256 = "76e1abb8a54f61ada974e6e9af689c59fd9f0518b49be6be7a631ce9fa45f236",
@@ -74,15 +76,18 @@ http_archive(
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
-
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+
 scala_config(scala_version = "2.12.7")
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+
 scala_repositories()
 
 FLINK_VERSION = "1.14.0"
+
 FLINK_ML_VERSION = "2.0.0"
+
 SCALA_VERSION = "2.12"
 
 maven_install(
@@ -107,13 +112,6 @@ maven_install(
         "org.apache.commons:commons-lang3:3.3.2",
         "junit:junit:4.12",
     ],
-    repositories = [
-        "https://maven.google.com",
-        "https://repo1.maven.org/maven2",
-        "http://packages.confluent.io/maven",
-        "http://mvnrepo.alibaba-inc.com/mvn/repository",
-        "https://repository.apache.org/content/repositories/orgapacheflink-1473",
-    ],
     override_targets = {
         "org.scala-lang.scala-library": "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library",
         "org.scala-lang.scala-reflect": "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect",
@@ -121,4 +119,35 @@ maven_install(
         "org.scala-lang.modules.scala-parser-combinators_2.11": "@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators",
         "org.scala-lang.modules.scala-xml_2.11": "@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml",
     },
+    repositories = [
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+        "http://packages.confluent.io/maven",
+        "http://mvnrepo.alibaba-inc.com/mvn/repository",
+        "https://repository.apache.org/content/repositories/orgapacheflink-1473",
+    ],
+)
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.17.2")
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    sha256 = "0d3ca4ed434958dda241fb129f77bd5ef0ce246250feed2d5a5470c6f29a77fa",
+    strip_prefix = "buildtools-4.0.0",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.0.0.tar.gz",
+    ],
 )

--- a/cpp_tests/BUILD
+++ b/cpp_tests/BUILD
@@ -27,14 +27,22 @@ tfrt_cc_library(
     visibility = [
         "//visibility:public",
     ],
+    deps = [
+        "@clink//:clink_kernels",
+        "@clink//:clink_kernels_alwayslink",
+        "@clink//:clink_kernels_opdefs",
+        "@clink//:clink_utils",
+        "@com_google_googletest//:gtest_main",
+        "@tf_runtime//:basic_kernels_alwayslink",
+        "@tf_runtime//:hostcontext_alwayslink",
+    ],
 )
 
 tfrt_cc_test(
     name = "linalg/sparse_vector_test",
     srcs = ["linalg/sparse_vector_test.cc"],
     deps = [
-        "@com_google_googletest//:gtest_main",
-        "@clink//:clink_kernels",
+        ":common",
     ],
 )
 
@@ -43,7 +51,5 @@ tfrt_cc_test(
     srcs = ["feature/one_hot_encoder_test.cc"],
     deps = [
         ":common",
-        "@com_google_googletest//:gtest_main",
-        "@clink//:clink_kernels",
     ],
 )

--- a/cpp_tests/include/clink/cpp_tests/test_util.h
+++ b/cpp_tests/include/clink/cpp_tests/test_util.h
@@ -18,60 +18,91 @@
 #ifndef CLINK_CPP_TESTS_TEST_UTIL_H_
 #define CLINK_CPP_TESTS_TEST_UTIL_H_
 
-#include <cstdlib>
-#include <cstring>
 #include <dirent.h>
-#include <stdio.h>
+#include <fstream>
+#include <sys/stat.h>
+
+#include "clink/kernels/opdefs/clink_kernels.h"
+#include "clink/utils/clink_runner.h"
+#include "clink/utils/clink_utils.h"
+#include "google/protobuf/message.h"
+#include "nlohmann/json.hpp"
+#include "tfrt/basic_kernels/opdefs/basic_kernels.h"
 
 namespace clink {
 namespace test {
 
-std::string createTemporaryFolder() {
-  char dir_template[] = "/tmp/clink-test-tmp.XXXXXX";
-  std::string dir_name = std::string(mkdtemp(dir_template));
-  return dir_name;
-}
+// This class represents a temporary folder used for unit tests. The folder will
+// be deleted automatically once this object is freed.
+class TemporaryFolder {
+public:
+  TemporaryFolder() {
+    char dir_template[] = "/tmp/clink-test-tmp.XXXXXX";
+    dir_name = std::string(mkdtemp(dir_template));
+  }
 
-std::string generateRandomString() {
-  const int len = 6;
-  static char possible_chars[62] = {};
-  for (int i = 0; i < 10; i++) {
-    possible_chars[i] = i + '0';
-  }
-  for (int i = 0; i < 26; i++) {
-    possible_chars[i + 10] = i + 'a';
-    possible_chars[i + 36] = i + 'A';
-  }
-  char tmp[len + 1];
-  for (int i = 0; i < len; i++) {
-    tmp[i] = possible_chars[rand() % 62];
-  }
-  return std::string(tmp);
-}
+  ~TemporaryFolder() { deleteFolderRecursively(dir_name); }
 
-void deleteFolderRecursively(std::string path) {
-  struct dirent *entry;
-  struct stat st;
-  DIR *dir = opendir(path.c_str());
+  const std::string getAbsolutePath() { return dir_name; }
 
-  if (dir == NULL) {
-    return;
-  }
-  while ((entry = readdir(dir)) != NULL) {
-    const std::string full_file_name = path + "/" + entry->d_name;
-    if (stat(full_file_name.c_str(), &st) == -1)
-      continue;
-    bool is_directory = (st.st_mode & S_IFDIR) != 0;
-    if (is_directory) {
-      if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-        continue;
-      deleteFolderRecursively(full_file_name);
-    } else {
-      remove(full_file_name.c_str());
+private:
+  void deleteFolderRecursively(std::string path) {
+    struct dirent *entry;
+    struct stat st;
+    DIR *dir = opendir(path.c_str());
+
+    if (dir == NULL) {
+      return;
     }
+    while ((entry = readdir(dir)) != NULL) {
+      const std::string full_file_name = path + "/" + entry->d_name;
+      if (stat(full_file_name.c_str(), &st) == -1)
+        continue;
+      bool is_directory = (st.st_mode & S_IFDIR) != 0;
+      if (is_directory) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+          continue;
+        deleteFolderRecursively(full_file_name);
+      } else {
+        remove(full_file_name.c_str());
+      }
+    }
+    closedir(dir);
+    remove(path.c_str());
   }
-  closedir(dir);
-  remove(path.c_str());
+
+  std::string dir_name;
+};
+
+// Mocks Flink ML's `Stage.save(String path)` method to save metadata and model
+// data of an Clink operator to a given directory.
+void saveMetaDataModelData(std::string dir_name, nlohmann::json params,
+                           google::protobuf::Message &model_data) {
+  std::ofstream params_output(dir_name + "/metadata");
+  params_output << params;
+  params_output.close();
+
+  mkdir((dir_name + "/data").c_str(), S_IRUSR | S_IWUSR);
+  std::ofstream model_data_output(dir_name + "/data/part-0");
+  model_data.SerializeToOstream(&model_data_output);
+  model_data_output.close();
+}
+
+// Creates a ClinkRunner, executes the provided mlir script and returns the
+// execution result.
+llvm::SmallVector<RCReference<AsyncValue>, 4>
+runMlirScript(tfrt::HostContext *host_context, MLIRContext *mlir_context,
+              string_view mlir_script,
+              llvm::ArrayRef<RCReference<AsyncValue>> inputs) {
+  // Initializes ClinkRunner.
+  clink::ClinkRunner::Builder builder;
+  builder.set_mlir_fn_name("main")
+      .set_mlir_input(mlir_script)
+      .set_host_context(host_context)
+      .set_mlir_context(mlir_context);
+  auto runner = builder.Compile();
+
+  return runner.Run(inputs);
 }
 
 } // namespace test

--- a/cpp_tests/linalg/sparse_vector_test.cc
+++ b/cpp_tests/linalg/sparse_vector_test.cc
@@ -15,18 +15,21 @@
  */
 
 #include "clink/linalg/sparse_vector.h"
+
+#include "clink/cpp_tests/test_util.h"
 #include "gtest/gtest.h"
 
-namespace tfrt {
+namespace clink {
+
 namespace {
 
 TEST(SparseVectorTest, CreatesVector) {
-  clink::SparseVector vector(5);
+  SparseVector vector(5);
   EXPECT_EQ(vector.size(), 5);
 }
 
 TEST(SparseVectorTest, SetGetValue) {
-  clink::SparseVector vector(5);
+  SparseVector vector(5);
   vector.set(1, 1.0);
   vector.set(2, 3.0);
   vector.set(4, 2.5);
@@ -35,9 +38,9 @@ TEST(SparseVectorTest, SetGetValue) {
   EXPECT_EQ(vector.get(2).get(), 3.0);
   EXPECT_EQ(vector.get(3).get(), 0.0);
   EXPECT_EQ(vector.get(4).get(), 2.5);
-  EXPECT_EQ(!vector.get(4).takeError(), true);
-  EXPECT_EQ(!vector.get(5).takeError(), false);
+  EXPECT_FALSE((bool)vector.get(4).takeError());
+  EXPECT_TRUE((bool)vector.get(5).takeError());
 }
 
 } // namespace
-} // namespace tfrt
+} // namespace clink

--- a/include/clink/api/model.h
+++ b/include/clink/api/model.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The Clink Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CLINK_API_MODEL_H_
+#define CLINK_API_MODEL_H_
+
+#include "tfrt/host_context/host_allocator.h"
+#include "tfrt/support/ref_count.h"
+
+namespace clink {
+
+// Basic interface for Clink operators that provides feature processing
+// function.
+class Model : public tfrt::ReferenceCounted<Model> {
+public:
+  virtual ~Model() {}
+
+  template <typename SubClass>
+  void DestroyImpl(SubClass *ptr, tfrt::HostAllocator *allocator) {
+    ptr->~SubClass();
+    allocator->DeallocateBytes(ptr, sizeof(SubClass));
+  }
+
+private:
+  // For access to Destroy().
+  friend class ReferenceCounted<Model>;
+
+  virtual void Destroy() = 0;
+};
+
+} // namespace clink
+
+#endif // CLINK_API_MODEL_H_

--- a/include/clink/kernels/opdefs/clink_kernels.h
+++ b/include/clink/kernels/opdefs/clink_kernels.h
@@ -19,8 +19,7 @@
 #ifndef CLINK_KERNELS_OPDEFS_CLINK_KERNELS_H_
 #define CLINK_KERNELS_OPDEFS_CLINK_KERNELS_H_
 
-#include "mlir/IR/Dialect.h"
-#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/DialectImplementation.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 
 using namespace mlir;
@@ -32,6 +31,10 @@ class ClinkDialect : public Dialect {
 public:
   static StringRef getDialectNamespace() { return "clink"; }
   explicit ClinkDialect(MLIRContext *context);
+
+  mlir::Type parseType(mlir::DialectAsmParser &parser) const override;
+  void printType(mlir::Type type,
+                 mlir::DialectAsmPrinter &printer) const override;
 };
 
 } // namespace clink

--- a/include/clink/kernels/opdefs/clink_kernels.td
+++ b/include/clink/kernels/opdefs/clink_kernels.td
@@ -22,8 +22,7 @@
 #else
 #define CLINK_OPS
 
-include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/InferTypeOpInterface.td"
+include "tfrt/basic_kernels/opdefs/tfrt_base.td"
 
 // "clink" dialect
 def Clink_Dialect : Dialect {
@@ -43,6 +42,18 @@ class Clink_Op<string mnemonic, list<OpTrait> traits = []> :
   // Each registered op in the Clink namespace needs to provide a parser.
   let parser = [{ return clink::parse$cppClass(parser, result); }];
 }
+
+//===----------------------------------------------------------------------===//
+// Clink types
+//===----------------------------------------------------------------------===//
+
+def Clink_ModelType :
+  Type<CPred<"$_self.isa<clink::ModelType>()">, "!clink.model type">,
+  BuildableType<"$_builder.getType<clink::ModelType>()">;
+
+def Clink_VectorType :
+  Type<CPred<"$_self.isa<clink::VectorType>()">, "!clink.vector type">,
+  BuildableType<"$_builder.getType<clink::VectorType>()">;
 
 //===----------------------------------------------------------------------===//
 // Clink ops
@@ -72,6 +83,43 @@ def SquareF64Op: Clink_Op<"square.f64"> {
   }];
   let arguments = (ins F64);
   let results = (outs F64);
+  let assemblyFormat = "operands attr-dict";
+  let verifier = ?;
+}
+
+def OneHotEncoderLoadOp: Clink_Op<"onehotencoder_load"> {
+  let summary = "onehotencoder_load operation";
+  let description = [{
+     An operation that loads a OneHotEncoderModel from a given path. The path should be a directory
+     containing params and model data saved through
+     org.clink.feature.onehotencoder.ClinkOneHotEnoderModel::save(...).
+
+     Example:
+       %1 = clink.onehotencoder_load %0
+  }];
+  let arguments = (ins TFRT_StringType:$path);
+  let results = (outs Clink_ModelType:$model);
+  let assemblyFormat = "operands attr-dict";
+  let verifier = ?;
+}
+
+// TODO: Change this to generic kernels for load and transform operations
+def OneHotEncoderTransformOp: Clink_Op<"onehotencoder_transform"> {
+  let summary = "onehotencoder_transform operation";
+  let description = [{
+     An operation that transforms data based on a OneHotEncoderModel. It takes a value
+     and its index among all columns in a database table that needs to be one-hot
+     encoded, and returns the resulting encoded sparse vector.
+
+     Example:
+       %3 = clink.onehotencoder_transform %0, %1, %2
+  }];
+  let arguments = (ins 
+    Clink_ModelType:$model,
+    I32:$value,
+    I32:$column_index
+  );
+  let results = (outs Clink_VectorType:$vector);
   let assemblyFormat = "operands attr-dict";
   let verifier = ?;
 }

--- a/include/clink/kernels/opdefs/types.h
+++ b/include/clink/kernels/opdefs/types.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Clink Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CLINK_FEATURE_OPDEFS_TYPES_H_
+#define CLINK_FEATURE_OPDEFS_TYPES_H_
+
+#include "mlir/IR/Types.h"
+
+namespace clink {
+
+class ModelType
+    : public mlir::Type::TypeBase<ModelType, mlir::Type, mlir::TypeStorage> {
+public:
+  using Base::Base;
+};
+
+class VectorType
+    : public mlir::Type::TypeBase<VectorType, mlir::Type, mlir::TypeStorage> {
+public:
+  using Base::Base;
+};
+
+} // namespace clink
+
+#endif // CLINK_FEATURE_OPDEFS_TYPES_H_

--- a/include/clink/linalg/sparse_vector.h
+++ b/include/clink/linalg/sparse_vector.h
@@ -17,18 +17,16 @@
 #ifndef CLINK_LINALG_SPARSE_VECTOR_H_
 #define CLINK_LINALG_SPARSE_VECTOR_H_
 
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Errc.h"
-#include "llvm/Support/Error.h"
+#include "clink/linalg/vector.h"
 
 namespace clink {
 
 // A sparse vector of double values.
-class SparseVector {
+class SparseVector : public Vector {
 public:
   // Constructor for SparseVector.
   // `n` stands for the number of dimensions of the vector.
-  SparseVector(const int n) : n_(n) {}
+  explicit SparseVector(const int n) : n_(n) {}
 
   // Move operations are supported.
   SparseVector(SparseVector &&other) = default;
@@ -42,10 +40,12 @@ public:
   llvm::Error set(const int index, const double value);
 
   // Gets the value at a certain index of the vector.
-  llvm::Expected<double> get(const int index);
+  llvm::Expected<double> get(const int index) const;
 
   // Gets the total number of dimensions of the vector.
-  int size();
+  int size() const;
+
+  bool operator==(const SparseVector &other) const;
 
 private:
   const int n_;

--- a/include/clink/linalg/vector.h
+++ b/include/clink/linalg/vector.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 The Clink Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CLINK_LINALG_VECTOR_H_
+#define CLINK_LINALG_VECTOR_H_
+
+#include "tfrt/host_context/chain.h"
+
+namespace clink {
+
+// A vector of double values.
+class Vector {
+public:
+  // Sets the value at a certain index of the vector.
+  virtual llvm::Error set(const int index, const double value) = 0;
+
+  // Gets the value at a certain index of the vector.
+  virtual llvm::Expected<double> get(const int index) const = 0;
+
+  // Gets the total number of dimensions of the vector.
+  virtual int size() const = 0;
+
+protected:
+  // Move operations are supported.
+  Vector(Vector &&other) = default;
+  Vector &operator=(Vector &&other) = default;
+
+  // This class is not copyable or assignable.
+  Vector(const Vector &other) = delete;
+  Vector &operator=(const Vector &) = delete;
+
+  Vector() = default;
+
+  virtual ~Vector() {}
+};
+
+} // namespace clink
+
+#endif // CLINK_LINALG_VECTOR_H_

--- a/include/clink/utils/clink_runner.h
+++ b/include/clink/utils/clink_runner.h
@@ -78,7 +78,7 @@ public:
   };
 
   // Runs the MLIR function on TFRT and returns the outputs.
-  llvm::SmallVector<RCReference<AsyncValue>>
+  llvm::SmallVector<RCReference<AsyncValue>, 4>
   Run(llvm::ArrayRef<RCReference<AsyncValue>> inputs);
 
 private:

--- a/include/clink/utils/clink_utils.h
+++ b/include/clink/utils/clink_utils.h
@@ -25,6 +25,17 @@ std::unique_ptr<tfrt::HostContext>
 CreateHostContext(string_view work_queue_type,
                   tfrt::HostAllocatorType host_allocator_type);
 
+// Given a directory path, gets the only file in the directory.
+//
+// In Flink ML operators that produces model data as a protobuf record, they
+// save model data in a directory with only one file. C++ knows the directory of
+// the file, but the file's name is unknown to C++. This function helps to
+// locate that file.
+//
+// This function returns empty string if the directory does not exist, or there
+// is zero or more than one file in the directory.
+std::string getOnlyFileInDirectory(std::string path);
+
 } // namespace clink
 
 #endif // CLINK_UTILS_CLINK_UTILS_H_

--- a/java-lib/src/main/java/org/flinkextended/clink/jna/ClinkJna.java
+++ b/java-lib/src/main/java/org/flinkextended/clink/jna/ClinkJna.java
@@ -34,6 +34,7 @@ public interface ClinkJna extends Library {
      *
      * @param vector A reference to the {@link SparseVectorJna} object.
      */
+    // TODO: Automatically free C++ objects to avoid memory leak and improve usability.
     void SparseVector_delete(SparseVectorJna.ByReference vector);
 
     /**
@@ -59,6 +60,7 @@ public interface ClinkJna extends Library {
      * @param columnIndex The column index which the indexed integer locates
      * @return A one-hot-encoded sparse vector
      */
+    // TODO: Compare the performance of using ByReference v.s. ByValue and optimize accordingly.
     SparseVectorJna.ByReference OneHotEncoderModel_transform(
             Pointer modelPointer, int value, int columnIndex) throws LastErrorException;
 

--- a/lib/executor/main.cc
+++ b/lib/executor/main.cc
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
   auto runner = builder.Compile();
 
   // Executes ClinkRunner.
-  llvm::SmallVector<RCReference<AsyncValue>> inputs;
+  llvm::SmallVector<RCReference<AsyncValue>, 4> inputs;
   inputs.push_back(tfrt::MakeAvailableAsyncValueRef<double>(2.0));
   auto results = runner.Run(inputs);
 

--- a/lib/feature/one_hot_encoder.cc
+++ b/lib/feature/one_hot_encoder.cc
@@ -14,36 +14,33 @@
  * limitations under the License.
  */
 
-#include "fstream"
-#include "sys/stat.h"
-#include <dirent.h>
-#include <string>
-
 #include "clink/feature/one_hot_encoder.h"
+
+#include <fstream>
+
+#include "clink/utils/clink_utils.h"
 #include "nlohmann/json.hpp"
-#include "tfrt/support/error_util.h"
 
-using namespace clink;
-using namespace std;
-using namespace nlohmann;
+namespace clink {
 
-llvm::Expected<SparseVector>
-OneHotEncoderModel::transform(const int value, const int columnIndex) {
-  if (columnIndex >= model_data_.featuresizes_size()) {
-    return tfrt::MakeStringError("Column index out of range.");
+tfrt::AsyncValueRef<SparseVector>
+OneHotEncoderModel::transform(const int value, const int column_index) const {
+  if (column_index >= model_data_.featuresizes_size()) {
+    return tfrt::MakeErrorAsyncValueRef("Column index out of range.");
   }
 
-  int len = model_data_.featuresizes(columnIndex);
+  int len = model_data_.featuresizes(column_index);
   if (value >= len) {
-    return tfrt::MakeStringError("Value out of range.");
+    return tfrt::MakeErrorAsyncValueRef("Value out of range.");
   }
   if (getDropLast()) {
     len -= 1;
   }
 
-  SparseVector vector(len);
+  tfrt::AsyncValueRef<SparseVector> vector =
+      tfrt::MakeAvailableAsyncValueRef<SparseVector>(len);
   if (value < len) {
-    vector.set(value, 1.0);
+    vector->set(value, 1.0);
   }
   return vector;
 }
@@ -52,9 +49,10 @@ void OneHotEncoderModel::setDropLast(const bool is_droplast) {
   params_.is_droplast = is_droplast;
 }
 
-bool OneHotEncoderModel::getDropLast() { return params_.is_droplast; }
+bool OneHotEncoderModel::getDropLast() const { return params_.is_droplast; }
 
-llvm::Error OneHotEncoderModel::setModelData(const std::string model_data_str) {
+llvm::Error
+OneHotEncoderModel::setModelData(const std::string &model_data_str) {
   OneHotEncoderModelDataProto model_data;
 
   if (!model_data.ParseFromString(model_data_str)) {
@@ -73,64 +71,29 @@ llvm::Error OneHotEncoderModel::setModelData(const std::string model_data_str) {
   return llvm::Error::success();
 }
 
-namespace {
-/*
- * Given a directory path, gets the single file in the directory.
- *
- * Flink ML saves model data in a file whose name is unknown to C++. This
- * function helps to locate that file.
- *
- * This function returns empty string if the directory does not exist, or there
- * is zero or more than one file in the directory.
- */
-std::string getOnlyFileInDirectory(std::string path) {
-  std::string result = "";
-  struct dirent *entry;
-  struct stat st;
-  DIR *dir = opendir(path.c_str());
+llvm::Expected<tfrt::RCReference<OneHotEncoderModel>>
+OneHotEncoderModel::load(const std::string &path, tfrt::HostContext *host) {
+  tfrt::RCReference<OneHotEncoderModel> model =
+      TakeRef(host->Construct<OneHotEncoderModel>(host));
 
-  if (dir == NULL) {
-    return "";
-  }
-  while ((entry = readdir(dir)) != NULL) {
-    const string full_file_name = path + "/" + entry->d_name;
-    if (stat(full_file_name.c_str(), &st) == -1)
-      continue;
-    bool is_directory = (st.st_mode & S_IFDIR) != 0;
-    if (!is_directory) {
-      if (result.compare("")) {
-        return "";
-      }
-      result = std::string(entry->d_name);
-    }
-  }
-  closedir(dir);
-  return result;
-}
-} // anonymous namespace
-
-llvm::Expected<OneHotEncoderModel>
-OneHotEncoderModel::load(const std::string path) {
-  OneHotEncoderModel model;
-
-  ifstream params_input(path + "/metadata");
-  json params;
+  std::ifstream params_input(path + "/metadata");
+  nlohmann::json params;
   params << params_input;
   std::string is_droplast = params["paramMap"]["dropLast"].get<std::string>();
-  model.setDropLast(is_droplast.compare("false"));
+  model->setDropLast(is_droplast != "false");
   params_input.close();
 
   std::string model_data_filename = getOnlyFileInDirectory(path + "/data");
-  if (!model_data_filename.compare("")) {
+  if (model_data_filename == "") {
     return tfrt::MakeStringError(
         "Failed to load OneHotEncoderModel: model data directory " + path +
         "/data does not exist, or it has zero or more than one file.");
   }
 
-  ifstream model_data_input(path + "/data/" + model_data_filename);
+  std::ifstream model_data_input(path + "/data/" + model_data_filename);
   std::string model_data_str((std::istreambuf_iterator<char>(model_data_input)),
                              std::istreambuf_iterator<char>());
-  llvm::Error err = model.setModelData(model_data_str);
+  llvm::Error err = model->setModelData(std::move(model_data_str));
   model_data_input.close();
 
   if (err) {
@@ -141,3 +104,5 @@ OneHotEncoderModel::load(const std::string path) {
 
   return model;
 }
+
+} // namespace clink

--- a/lib/kernels/clink_kernels.cc
+++ b/lib/kernels/clink_kernels.cc
@@ -14,11 +14,26 @@
 
 #include "clink/kernels/clink_kernels.h"
 
+#include "clink/feature/one_hot_encoder.h"
+#include "clink/linalg/sparse_vector.h"
 #include "tfrt/host_context/async_dispatch.h"
+#include "tfrt/host_context/kernel_utils.h"
 
 using namespace tfrt;
 
 namespace clink {
+
+#define CLINK_RETURN_IF_ERROR(KERNEL_ERROR, ERR)                               \
+  do {                                                                         \
+    if (auto err = ERR) {                                                      \
+      llvm::Error unknown = llvm::handleErrors(                                \
+          std::move(err), [&](const llvm::StringError &err) {                  \
+            KERNEL_ERROR.ReportError(err.getMessage());                        \
+          });                                                                  \
+      assert(!unknown && "Unknown error type");                                \
+      return;                                                                  \
+    }                                                                          \
+  } while (0)
 
 AsyncValueRef<double> SquareAdd(Argument<double> x, Argument<double> y,
                                 const ExecutionContext &exec_ctx) {
@@ -31,7 +46,7 @@ AsyncValueRef<double> SquareAdd(Argument<double> x, Argument<double> y,
   AsyncValueRef<double> y_square =
       EnqueueWork(exec_ctx, [y = y.ValueRef()] { return y.get() * y.get(); });
 
-  SmallVector<AsyncValue *, 2> async_values;
+  SmallVector<AsyncValue *, 4> async_values;
   async_values.push_back(x_square.GetAsyncValue());
   async_values.push_back(y_square.GetAsyncValue());
 
@@ -49,6 +64,22 @@ AsyncValueRef<double> SquareAdd(Argument<double> x, Argument<double> y,
 
 double Square(double x) { return x * x; }
 
+void OneHotEncoderLoad(Argument<std::string> path,
+                       Result<RCReference<OneHotEncoderModel>> result_model,
+                       KernelErrorHandler handler,
+                       const ExecutionContext &exec_ctx) {
+  auto model = OneHotEncoderModel::load(path.get(), exec_ctx.host());
+  CLINK_RETURN_IF_ERROR(handler, model.takeError());
+  result_model.Emplace(model.get());
+}
+
+AsyncValueRef<SparseVector>
+OneHotEncoderTransform(RCReference<OneHotEncoderModel> model,
+                       Argument<int> value, Argument<int> column_index,
+                       const ExecutionContext &exec_ctx) {
+  return model->transform(value.get(), column_index.get());
+}
+
 //===----------------------------------------------------------------------===//
 // Registration
 //===----------------------------------------------------------------------===//
@@ -56,6 +87,10 @@ double Square(double x) { return x * x; }
 void RegisterClinkKernels(tfrt::KernelRegistry *registry) {
   registry->AddKernel("clink.square_add.f64", TFRT_KERNEL(SquareAdd));
   registry->AddKernel("clink.square.f64", TFRT_KERNEL(Square));
+  registry->AddKernel("clink.onehotencoder_load",
+                      TFRT_KERNEL(OneHotEncoderLoad));
+  registry->AddKernel("clink.onehotencoder_transform",
+                      TFRT_KERNEL(OneHotEncoderTransform));
 }
 
 } // namespace clink

--- a/lib/linalg/sparse_vector.cc
+++ b/lib/linalg/sparse_vector.cc
@@ -15,13 +15,11 @@
  */
 
 #include "clink/linalg/sparse_vector.h"
-#include "tfrt/support/error_util.h"
 
-using namespace clink;
-using namespace std;
+namespace clink {
 
-llvm::Expected<double> SparseVector::get(const int index) {
-  if (index >= n_) {
+llvm::Expected<double> SparseVector::get(const int index) const {
+  if (index >= n_ || index < 0) {
     return tfrt::MakeStringError("Index out of range.");
   }
 
@@ -50,4 +48,18 @@ llvm::Error SparseVector::set(const int index, const double value) {
   return llvm::Error::success();
 }
 
-int SparseVector::size() { return n_; }
+int SparseVector::size() const { return n_; }
+
+bool SparseVector::operator==(const SparseVector &other) const {
+  if (n_ != other.n_) {
+    return false;
+  }
+  for (int i = 0; i < n_; i++) {
+    if (this->get(i).get() != other.get(i).get()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace clink

--- a/lib/utils/clink_runner.cc
+++ b/lib/utils/clink_runner.cc
@@ -52,7 +52,7 @@ ClinkRunner::ClinkRunner(const std::string &fn_name, BefBuffer bef_buffer,
   func_ = bef_file_->GetFunction(fn_name_);
 }
 
-llvm::SmallVector<RCReference<AsyncValue>>
+llvm::SmallVector<RCReference<AsyncValue>, 4>
 ClinkRunner::Run(ArrayRef<RCReference<AsyncValue>> inputs) {
   assert((func_->num_arguments() == inputs.size()) &&
          "Incorrect number of arguments set.");

--- a/tools/format-code.sh
+++ b/tools/format-code.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# This script formats all codes in the Clink repository. It uses clang-format to
+# format C++ code, diffplug/spotless to format Java code, and Buildifier to
+# format Bazel code.
+
+set -e
+
+# Checks whether required tools have been installed
+for cmd in clang-format mvn
+do
+    if ! command -v $cmd &> /dev/null
+    then
+        echo "$cmd: command not found"
+        exit
+    fi
+done
+
+# TODO: change clang-format style to google
+# Formats C++ codes
+find . \( -name "*.cc" -or -name "*.h" \) -not -path "./tfrt/*" -exec clang-format -i -style=llvm {} \;
+
+# Formats Java codes
+mvn -f java-lib spotless:apply
+
+# Formats Bazel codes
+bazel run //:buildifier


### PR DESCRIPTION
This PR mainly does the following:

- Register OneHotEncoder methods as Clink kernels. 
- Add tests and corresponding utility functions to run OneHotEncoder kernels with MLIR scripts in ClinkRunner.
- Improve OneHotEncoder's core and jna implementation for deduplication and better readability.
- Use [Buildifier](https://github.com/bazelbuild/buildtools) to format Bazel scripts, and create bash script to format codes of all languages in one line.
- Reorganize README's information to improve readability