### PR TITLE
Add unified Model transform API

### DIFF
--- a/cpp_tests/feature/one_hot_encoder_test.cc
+++ b/cpp_tests/feature/one_hot_encoder_test.cc
@@ -30,6 +30,7 @@ class OneHotEncoderTest : public testing::Test {
     host_context =
         CreateHostContext("mstd", tfrt::HostAllocatorType::kLeakCheckMalloc)
             .release();
+
     assert(mlir_context == nullptr);
     mlir_context = new MLIRContext();
     mlir_context->allowUnregisteredDialects();
@@ -38,22 +39,31 @@ class OneHotEncoderTest : public testing::Test {
     registry.insert<clink::ClinkDialect>();
     registry.insert<tfrt::compiler::TFRTDialect>();
     mlir_context->appendDialectRegistry(registry);
+
+    assert(exec_context == nullptr);
+    exec_context = new ExecutionContext(
+        *tfrt::RequestContextBuilder(host_context, nullptr).build());
   }
 
   static void TearDownTestSuite() {
     delete host_context;
-    host_context = nullptr;
     delete mlir_context;
+    delete exec_context;
+    host_context = nullptr;
     mlir_context = nullptr;
+    exec_context = nullptr;
   }
 
   static tfrt::HostContext *host_context;
   static MLIRContext *mlir_context;
+  static ExecutionContext *exec_context;
 };
 
 tfrt::HostContext *OneHotEncoderTest::host_context = nullptr;
 
 MLIRContext *OneHotEncoderTest::mlir_context = nullptr;
+
+ExecutionContext *OneHotEncoderTest::exec_context = nullptr;
 
 TEST_F(OneHotEncoderTest, Param) {
   RCReference<OneHotEncoderModel> model =
@@ -79,14 +89,31 @@ TEST_F(OneHotEncoderTest, Transform) {
 
   SparseVector expected_vector(2);
   expected_vector.set(1, 1.0);
-  auto actual_vector = model->transform(1, 0);
-  EXPECT_EQ(actual_vector.get(), expected_vector);
 
-  auto invalid_value_vector = model->transform(1, 5);
-  EXPECT_TRUE(invalid_value_vector.IsError());
+  {
+    tfrt::AsyncValueRef<int> value_ref = MakeAvailableAsyncValueRef<int>(1);
+    tfrt::AsyncValueRef<int> colum_index_ref =
+        MakeAvailableAsyncValueRef<int>(0);
+    llvm::SmallVector<tfrt::AsyncValue *, 4> inputs{
+        value_ref.GetAsyncValue(), colum_index_ref.GetAsyncValue()};
 
-  auto invalid_index_vector = model->transform(5, 0);
-  EXPECT_TRUE(invalid_index_vector.IsError());
+    auto outputs = model->transform(inputs, *exec_context);
+    host_context->Await(outputs);
+    SparseVector &actual_vector = outputs[0]->get<SparseVector>();
+    EXPECT_EQ(actual_vector, expected_vector);
+  }
+
+  {
+    tfrt::AsyncValueRef<int> value_ref = MakeAvailableAsyncValueRef<int>(5);
+    tfrt::AsyncValueRef<int> colum_index_ref =
+        MakeAvailableAsyncValueRef<int>(5);
+    llvm::SmallVector<tfrt::AsyncValue *, 4> inputs{
+        value_ref.GetAsyncValue(), colum_index_ref.GetAsyncValue()};
+
+    auto outputs = model->transform(inputs, *exec_context);
+    host_context->Await(outputs);
+    EXPECT_EQ(outputs[0]->GetError().message, "Column index out of range.");
+  }
 }
 
 TEST_F(OneHotEncoderTest, Load) {
@@ -107,8 +134,16 @@ TEST_F(OneHotEncoderTest, Load) {
 
   SparseVector expected_vector(2);
   expected_vector.set(1, 1.0);
-  auto actual_vector = model.get()->transform(1, 0);
-  EXPECT_EQ(actual_vector.get(), expected_vector);
+
+  tfrt::AsyncValueRef<int> value_ref = MakeAvailableAsyncValueRef<int>(1);
+  tfrt::AsyncValueRef<int> colum_index_ref = MakeAvailableAsyncValueRef<int>(0);
+  llvm::SmallVector<tfrt::AsyncValue *, 4> inputs{
+      value_ref.GetAsyncValue(), colum_index_ref.GetAsyncValue()};
+
+  auto outputs = model.get()->transform(inputs, *exec_context);
+  host_context->Await(outputs);
+  SparseVector &actual_vector = outputs[0]->get<SparseVector>();
+  EXPECT_EQ(actual_vector, expected_vector);
 }
 
 TEST_F(OneHotEncoderTest, Mlir) {
@@ -123,42 +158,58 @@ TEST_F(OneHotEncoderTest, Mlir) {
 
   test::saveMetaDataModelData(tmp_folder.getAbsolutePath(), params, model_data);
 
-  // TODO: Separate the load process that is triggered only once and the
-  // repeatedly triggered transform process into different scripts.
-  auto mlir_script = R"mlir(
-    func @main(%path: !tfrt.string, %value: i32, %column_index: i32) -> !clink.vector {
-      %model = clink.onehotencoder_load %path
-      %vector = clink.onehotencoder_transform %model, %value, %column_index
-      tfrt.return %vector : !clink.vector
+  const std::string mlir_script = R"mlir(
+    func @load_model(%path: !tfrt.string) -> !clink.model {
+      %model = clink.load.onehotencoder %path
+      tfrt.return %model : !clink.model
+    }
+
+    func @transform_inputs(%model: !clink.model, %value: i32, %column_index: i32) -> !clink.vector {
+        %outputs = clink.transform %model, %value, %column_index : (i32, i32) -> !clink.vector
+        tfrt.return %outputs : !clink.vector
     }
   )mlir";
 
-  llvm::SmallVector<RCReference<AsyncValue>, 4> inputs;
-  inputs.push_back(tfrt::MakeAvailableAsyncValueRef<std::string>(
-      tmp_folder.getAbsolutePath()));
-  inputs.push_back(tfrt::MakeAvailableAsyncValueRef<int32_t>(1));
-  inputs.push_back(tfrt::MakeAvailableAsyncValueRef<int32_t>(0));
+  clink::ClinkRunner::Builder builder;
+  builder.set_mlir_fn_name("load_model")
+      .set_mlir_input(mlir_script)
+      .set_host_context(host_context)
+      .set_mlir_context(mlir_context);
+  auto model_load_runner = builder.Compile();
 
-  auto results =
-      test::runMlirScript(host_context, mlir_context, mlir_script, inputs);
-  EXPECT_EQ(results.size(), 1);
-  host_context->Await(results);
-  SparseVector &actual_vector = results[0]->get<SparseVector>();
-  SparseVector expected_vector(2);
-  expected_vector.set(1, 1.0);
-  EXPECT_EQ(actual_vector, expected_vector);
+  llvm::SmallVector<RCReference<AsyncValue>> model_load_inputs{
+      tfrt::MakeAvailableAsyncValueRef<std::string>(
+          tmp_folder.getAbsolutePath())};
+  auto model_ref = model_load_runner.Run(model_load_inputs)[0];
 
-  llvm::SmallVector<RCReference<AsyncValue>, 4> invalid_inputs;
-  invalid_inputs.push_back(tfrt::MakeAvailableAsyncValueRef<std::string>(
-      tmp_folder.getAbsolutePath()));
-  invalid_inputs.push_back(tfrt::MakeAvailableAsyncValueRef<int32_t>(5));
-  invalid_inputs.push_back(tfrt::MakeAvailableAsyncValueRef<int32_t>(5));
+  builder.set_mlir_fn_name("transform_inputs");
+  auto model_transform_runner = builder.Compile();
 
-  auto invalid_results = test::runMlirScript(host_context, mlir_context,
-                                             mlir_script, invalid_inputs);
-  EXPECT_EQ(invalid_results.size(), 1);
-  host_context->Await(invalid_results);
-  EXPECT_TRUE(invalid_results[0]->IsError());
+  {
+    llvm::SmallVector<RCReference<AsyncValue>, 4> inputs;
+    inputs.push_back(model_ref);
+    inputs.push_back(MakeAvailableAsyncValueRef<int>(1));
+    inputs.push_back(MakeAvailableAsyncValueRef<int>(0));
+
+    auto results = model_transform_runner.Run(inputs);
+    host_context->Await(results);
+    SparseVector &actual_vector = results[0]->get<SparseVector>();
+
+    SparseVector expected_vector(2);
+    expected_vector.set(1, 1.0);
+    EXPECT_EQ(actual_vector, expected_vector);
+  }
+
+  {
+    llvm::SmallVector<RCReference<AsyncValue>, 4> inputs;
+    inputs.push_back(model_ref);
+    inputs.push_back(MakeAvailableAsyncValueRef<int>(5));
+    inputs.push_back(MakeAvailableAsyncValueRef<int>(5));
+
+    auto results = model_transform_runner.Run(inputs);
+    host_context->Await(results);
+    EXPECT_EQ(results[0]->GetError().message, "Column index out of range.");
+  }
 }
 
 }  // namespace

--- a/cpp_tests/linalg/sparse_vector_test.cc
+++ b/cpp_tests/linalg/sparse_vector_test.cc
@@ -39,7 +39,7 @@ TEST(SparseVectorTest, SetGetValue) {
   EXPECT_EQ(vector.get(3).get(), 0.0);
   EXPECT_EQ(vector.get(4).get(), 2.5);
   EXPECT_FALSE((bool)vector.get(4).takeError());
-  EXPECT_TRUE((bool)vector.get(5).takeError());
+  EXPECT_EQ(tfrt::StrCat(vector.get(5).takeError()), "Index out of range.");
 }
 
 }  // namespace

--- a/include/clink/api/model.h
+++ b/include/clink/api/model.h
@@ -17,6 +17,8 @@
 #ifndef CLINK_API_MODEL_H_
 #define CLINK_API_MODEL_H_
 
+#include "tfrt/host_context/async_dispatch.h"
+#include "tfrt/host_context/async_value.h"
 #include "tfrt/host_context/host_allocator.h"
 #include "tfrt/support/ref_count.h"
 
@@ -24,12 +26,25 @@ namespace clink {
 
 // Basic interface for Clink operators that provides feature processing
 // function.
+//
+// NOTE: every Model subclass should implement a static method with signature
+// `static llvm::Expected<tfrt::RCReference<T>> load(const std::string &path,
+// tfrt::HostContext *host)`, where `T` refers to the concrete subclass. This
+// static method should instantiate a new Model instance based on the data read
+// from the given path.
 class Model : public tfrt::ReferenceCounted<Model> {
  public:
   virtual ~Model() {}
 
+  // Applies the Model on the given ArrayRef of input AsyncValues and returns
+  // a SmallVector of AsyncValues.
+  virtual llvm::SmallVector<tfrt::RCReference<tfrt::AsyncValue>, 4> transform(
+      llvm::ArrayRef<tfrt::AsyncValue *> inputs,
+      const tfrt::ExecutionContext &exec_ctx) = 0;
+
+ protected:
   template <typename SubClass>
-  void DestroyImpl(SubClass *ptr, tfrt::HostAllocator *allocator) {
+  static void DestroyImpl(SubClass *ptr, tfrt::HostAllocator *allocator) {
     ptr->~SubClass();
     allocator->DeallocateBytes(ptr, sizeof(SubClass));
   }

--- a/include/clink/feature/one_hot_encoder.h
+++ b/include/clink/feature/one_hot_encoder.h
@@ -37,10 +37,9 @@ class OneHotEncoderModel : public Model {
   OneHotEncoderModel(const OneHotEncoderModel &other) = delete;
   OneHotEncoderModel &operator=(const OneHotEncoderModel &) = delete;
 
-  // TODO: Add a transform method with generic signature in the Model class
-  // Converts the provided data to a SparseVector.
-  tfrt::AsyncValueRef<SparseVector> transform(const int value,
-                                              const int column_index) const;
+  llvm::SmallVector<tfrt::RCReference<tfrt::AsyncValue>, 4> transform(
+      llvm::ArrayRef<tfrt::AsyncValue *> inputs,
+      const tfrt::ExecutionContext &exec_ctx) override;
 
   // Loads a OneHotEncoderModel from given path. The path should be a directory
   // containing params and model data saved through

--- a/include/clink/kernels/opdefs/clink_kernels.td
+++ b/include/clink/kernels/opdefs/clink_kernels.td
@@ -87,15 +87,16 @@ def SquareF64Op: Clink_Op<"square.f64"> {
   let verifier = ?;
 }
 
-def OneHotEncoderLoadOp: Clink_Op<"onehotencoder_load"> {
-  let summary = "onehotencoder_load operation";
+class LoadOp<string suffix> : Clink_Op<"load." # suffix> {
+  let summary = "clink.load operation";
   let description = [{
-     An operation that loads a OneHotEncoderModel from a given path. The path should be a directory
-     containing params and model data saved through
-     org.clink.feature.onehotencoder.ClinkOneHotEnoderModel::save(...).
+     An operation that creates a Model's subclass instance based on the 
+     data read from the given path. The path should be a directory
+     containing params and model data saved by Clink's corresponding Java 
+     operator's void save(String path) method.
 
      Example:
-       %1 = clink.onehotencoder_load %0
+       %1 = clink.load.onehotencoder %0
   }];
   let arguments = (ins TFRT_StringType:$path);
   let results = (outs Clink_ModelType:$model);
@@ -103,24 +104,26 @@ def OneHotEncoderLoadOp: Clink_Op<"onehotencoder_load"> {
   let verifier = ?;
 }
 
-// TODO: Change this to generic kernels for load and transform operations
-def OneHotEncoderTransformOp: Clink_Op<"onehotencoder_transform"> {
-  let summary = "onehotencoder_transform operation";
+def OneHotEncoderLoadOp : LoadOp<"onehotencoder">;
+
+def TransformOp: Clink_Op<"transform"> {
+  let summary = "transform operation";
   let description = [{
-     An operation that transforms data based on a OneHotEncoderModel. It takes a value
-     and its index among all columns in a database table that needs to be one-hot
-     encoded, and returns the resulting encoded sparse vector.
+     An operation that transforms data based on a Model. It applies the Model 
+     on any given input AsyncValues and returns the transformation results as 
+     AsyncValues.
+
+     The input (except Model, the first input argument) and result types must 
+     be specified after the colon.
 
      Example:
-       %3 = clink.onehotencoder_transform %0, %1, %2
+       %2 = clink.transform %model, %0, %1 : (i32, i32) -> !clink.vector
   }];
   let arguments = (ins 
     Clink_ModelType:$model,
-    I32:$value,
-    I32:$column_index
+    Variadic<AnyType>:$inputs
   );
-  let results = (outs Clink_VectorType:$vector);
-  let assemblyFormat = "operands attr-dict";
+  let results = (outs Variadic<AnyType>:$outputs);
   let verifier = ?;
 }
 


### PR DESCRIPTION
This PR mainly adds a unified `transform()` API to `Model` and all its subclasses. 

This PR also does the following:
- Make `OneHotEncoder`'s specific `transform` method non-async.
- Add tests that demonstrate the usage of the new API.