### PR TITLE
Add Action to run CI within Docker images

### DIFF
--- a/.github/workflows/clink_ci_docker.yml
+++ b/.github/workflows/clink_ci_docker.yml
@@ -1,0 +1,22 @@
+name: Clink CI Docker
+
+on: [push, pull_request]
+
+jobs:
+  bazel_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ["centos7.7.1908", "ubuntu16.04"]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Update submodules
+        run: git submodule update --init --recursive
+      - name: Pull Docker image
+        run: docker pull docker.io/flinkextended/clink:${{matrix.os}}
+      - name: Run tests in Docker image
+        run: |
+          docker run -t -v ${GITHUB_WORKSPACE}:/root/clink -w /root/clink \
+            docker.io/flinkextended/clink:${{matrix.os}} /bin/bash \
+            bazel test $(bazel query //...)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tfrt"]
 	path = tfrt
-	url = git@github.com:tensorflow/runtime.git
+	url = https://github.com/tensorflow/runtime.git

--- a/BUILD
+++ b/BUILD
@@ -161,8 +161,8 @@ java_library(
         "@maven//:org_apache_flink_flink_table_api_java_bridge_%s" % SCALA_VERSION,
         "@maven//:org_apache_flink_flink_table_planner_%s" % SCALA_VERSION,
         "@maven//:org_apache_flink_flink_table_runtime_%s" % SCALA_VERSION,
-        "@maven//:org_apache_flink_flink_ml_core",
-        "@maven//:org_apache_flink_flink_ml_iteration",
+        "@maven//:org_apache_flink_flink_ml_core_%s" % SCALA_VERSION,
+        "@maven//:org_apache_flink_flink_ml_iteration_%s" % SCALA_VERSION,
         "@maven//:org_apache_flink_flink_ml_lib_%s" % SCALA_VERSION,
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,8 +104,8 @@ maven_install(
         "org.apache.flink:flink-table-planner_%s:%s" % (SCALA_VERSION, FLINK_VERSION),
         "org.apache.flink:flink-table-runtime_%s:%s" % (SCALA_VERSION, FLINK_VERSION),
         "org.apache.flink:flink-test-utils-junit:%s" % FLINK_VERSION,
-        "org.apache.flink:flink-ml-core:%s" % FLINK_ML_VERSION,
-        "org.apache.flink:flink-ml-iteration:%s" % FLINK_ML_VERSION,
+        "org.apache.flink:flink-ml-core_%s:%s" % (SCALA_VERSION, FLINK_ML_VERSION),
+        "org.apache.flink:flink-ml-iteration_%s:%s" % (SCALA_VERSION, FLINK_ML_VERSION),
         "org.apache.flink:flink-ml-lib_%s:%s" % (SCALA_VERSION, FLINK_ML_VERSION),
         "org.apache.commons:commons-compress:1.21",
         "commons-collections:commons-collections:3.2.2",
@@ -124,7 +124,6 @@ maven_install(
         "https://repo1.maven.org/maven2",
         "http://packages.confluent.io/maven",
         "http://mvnrepo.alibaba-inc.com/mvn/repository",
-        "https://repository.apache.org/content/repositories/orgapacheflink-1473",
     ],
 )
 


### PR DESCRIPTION
This PR mainly adds Github Action configuration file to run Clink unit tests within Clink's Docker images.

Example of running this Action can be found at https://github.com/yunfengzhou-hub/clink/actions/runs/1726739836.

This PR also does the following:
- Changes submodule configuration url from `git` to `https`
- Changes Flink ML dependency from RC to formal release