### PR TITLE
Add automatic check for memory leak in unit tests

### DIFF
--- a/.github/workflows/clink_ci_docker.yml
+++ b/.github/workflows/clink_ci_docker.yml
@@ -19,4 +19,4 @@ jobs:
         run: |
           docker run -t -v ${GITHUB_WORKSPACE}:/root/clink -w /root/clink \
             docker.io/flinkextended/clink:${{matrix.os}} /bin/bash \
-            bazel test $(bazel query //...)
+            bazel test $(bazel query //...) -c dbg

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ above, please check the [TFRT](https://github.com/tensorflow/runtime) README for
 more detailed instructions to install, configure and verify Bazel, Clang, and
 libstdc++8.
 
-### Initializing Submodules before Building Clink from Source
+### Initializing Submodules before building Clink from Source
 
 After setting up the environment according to the instructions above and pulling
 Clink repository, please use the following command to initialize submodules like

--- a/README.md
+++ b/README.md
@@ -65,21 +65,14 @@ above, please check the [TFRT](https://github.com/tensorflow/runtime) README for
 more detailed instructions to install, configure and verify Bazel, Clang, and
 libstdc++8.
 
-### Building Clink from Source
+### Initializing Submodules before Building Clink from Source
 
 After setting up the environment according to the instructions above and pulling
-Clink repository, please use the following command to update submodules like
-TFRT.
+Clink repository, please use the following command to initialize submodules like
+TFRT before building any Clink target from source.
 
 ```bash
 $ git submodule update --init --recursive
-```
-
-Then, users can run the following command to build all targets and to run all
-tests.
-
-```bash
-$ bazel test $(bazel query //...)
 ```
 
 ### Executing Examples
@@ -94,6 +87,15 @@ $ bazel run //:executor -- `pwd`/mlir_test/executor/basic.mlir --work_queue_type
 <!-- TODO: Add detailed example illustrating the usage of Clink Runner API. -->
 
 ## Developer Guidelines
+
+### Running All Tests
+
+Developers can run the following command to build all targets and to run all
+tests.
+
+```bash
+$ bazel test $(bazel query //...) -c dbg
+```
 
 ### Code Formatting
 

--- a/java-lib/src/main/java/org/flinkextended/clink/feature/onehotencoder/ClinkOneHotEncoderModel.java
+++ b/java-lib/src/main/java/org/flinkextended/clink/feature/onehotencoder/ClinkOneHotEncoderModel.java
@@ -171,7 +171,10 @@ public class ClinkOneHotEncoderModel
         @Override
         public void close() throws Exception {
             super.close();
-            ClinkJna.INSTANCE.OneHotEncoderModel_delete(modelPointer);
+            if (modelPointer != null) {
+                ClinkJna.INSTANCE.OneHotEncoderModel_delete(modelPointer);
+                modelPointer = null;
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds automatic check for Clink C++ operator's memory leak in unit tests.

The check is based on existing tools provided by C++ itself and TFRT. C++ smart pointers and `tfrt::RCReference` objects automatically free themselves when there is no reference to them. `tfrt::LeakCheckAllocator` would check and `exit(1)` if there are memory chunks that are not freed yet.

In order to fully utilize `tfrt::LeakCheckAllocator` to track all memory allocations, This PR also replaces all `new ` and `std::unique_ptr::release()` methods with `LeakCheckAllocator`'s corresponding method (There is no `malloc` in Clink, otherwise they should also be removed).

The memory leak check is only enabled in DEBUG mode, which is explained in README, so users are still able to use Clink without performance loss.

This PR resolves Issue #11 .