### PR TITLE
Improve code format configs and Add Action checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/.github/workflows/clink_format.yml
+++ b/.github/workflows/clink_format.yml
@@ -1,0 +1,29 @@
+name: Clink Format
+
+on: [push, pull_request]
+
+jobs:
+  format_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Update submodules
+        run: git submodule update --init --recursive
+      - name: Check md5sum equality
+        run: |
+          pre_built_md5sum=`find ./ -type f -exec md5sum {} \; | md5sum`
+
+          echo "Running ./tools/format-code.sh"
+          ./tools/format-code.sh
+
+          post_built_md5sum=`find ./ -type f -exec md5sum {} \; | md5sum`
+
+          echo "Pre-formatted md5sum: $pre_built_md5sum"
+          echo "Post-formatted md5sum: $post_built_md5sum"
+          if [ "${pre_built_md5sum}" != "${post_built_md5sum}" ]; then
+            echo "Pre-formatted md5sum and Post-formatted md5sum do not equal."
+            echo "Please format all Clink codes using ./tools/format-code.sh" \
+                "before submitting commits."
+            exit 1
+          fi

--- a/cpp_tests/feature/one_hot_encoder_test.cc
+++ b/cpp_tests/feature/one_hot_encoder_test.cc
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#include "clink/cpp_tests/test_util.h"
 #include "clink/feature/one_hot_encoder.h"
+
+#include "clink/cpp_tests/test_util.h"
 #include "gtest/gtest.h"
 
 namespace clink {
@@ -23,7 +24,7 @@ namespace clink {
 namespace {
 
 class OneHotEncoderTest : public testing::Test {
-protected:
+ protected:
   static void SetUpTestSuite() {
     assert(host_context == nullptr);
     host_context =
@@ -160,5 +161,5 @@ TEST_F(OneHotEncoderTest, Mlir) {
   EXPECT_TRUE(invalid_results[0]->IsError());
 }
 
-} // namespace
-} // namespace clink
+}  // namespace
+}  // namespace clink

--- a/cpp_tests/include/clink/cpp_tests/test_util.h
+++ b/cpp_tests/include/clink/cpp_tests/test_util.h
@@ -19,8 +19,9 @@
 #define CLINK_CPP_TESTS_TEST_UTIL_H_
 
 #include <dirent.h>
-#include <fstream>
 #include <sys/stat.h>
+
+#include <fstream>
 
 #include "clink/kernels/opdefs/clink_kernels.h"
 #include "clink/utils/clink_runner.h"
@@ -35,7 +36,7 @@ namespace test {
 // This class represents a temporary folder used for unit tests. The folder will
 // be deleted automatically once this object is freed.
 class TemporaryFolder {
-public:
+ public:
   TemporaryFolder() {
     char dir_template[] = "/tmp/clink-test-tmp.XXXXXX";
     dir_name = std::string(mkdtemp(dir_template));
@@ -45,7 +46,7 @@ public:
 
   const std::string getAbsolutePath() { return dir_name; }
 
-private:
+ private:
   void deleteFolderRecursively(std::string path) {
     struct dirent *entry;
     struct stat st;
@@ -56,8 +57,7 @@ private:
     }
     while ((entry = readdir(dir)) != NULL) {
       const std::string full_file_name = path + "/" + entry->d_name;
-      if (stat(full_file_name.c_str(), &st) == -1)
-        continue;
+      if (stat(full_file_name.c_str(), &st) == -1) continue;
       bool is_directory = (st.st_mode & S_IFDIR) != 0;
       if (is_directory) {
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
@@ -90,10 +90,9 @@ void saveMetaDataModelData(std::string dir_name, nlohmann::json params,
 
 // Creates a ClinkRunner, executes the provided mlir script and returns the
 // execution result.
-llvm::SmallVector<RCReference<AsyncValue>, 4>
-runMlirScript(tfrt::HostContext *host_context, MLIRContext *mlir_context,
-              string_view mlir_script,
-              llvm::ArrayRef<RCReference<AsyncValue>> inputs) {
+llvm::SmallVector<RCReference<AsyncValue>, 4> runMlirScript(
+    tfrt::HostContext *host_context, MLIRContext *mlir_context,
+    string_view mlir_script, llvm::ArrayRef<RCReference<AsyncValue>> inputs) {
   // Initializes ClinkRunner.
   clink::ClinkRunner::Builder builder;
   builder.set_mlir_fn_name("main")
@@ -105,7 +104,7 @@ runMlirScript(tfrt::HostContext *host_context, MLIRContext *mlir_context,
   return runner.Run(inputs);
 }
 
-} // namespace test
-} // namespace clink
+}  // namespace test
+}  // namespace clink
 
-#endif // CLINK_CPP_TESTS_TEST_UTIL_H_
+#endif  // CLINK_CPP_TESTS_TEST_UTIL_H_

--- a/cpp_tests/linalg/sparse_vector_test.cc
+++ b/cpp_tests/linalg/sparse_vector_test.cc
@@ -42,5 +42,5 @@ TEST(SparseVectorTest, SetGetValue) {
   EXPECT_TRUE((bool)vector.get(5).takeError());
 }
 
-} // namespace
-} // namespace clink
+}  // namespace
+}  // namespace clink

--- a/include/clink/api/model.h
+++ b/include/clink/api/model.h
@@ -25,7 +25,7 @@ namespace clink {
 // Basic interface for Clink operators that provides feature processing
 // function.
 class Model : public tfrt::ReferenceCounted<Model> {
-public:
+ public:
   virtual ~Model() {}
 
   template <typename SubClass>
@@ -34,13 +34,13 @@ public:
     allocator->DeallocateBytes(ptr, sizeof(SubClass));
   }
 
-private:
+ private:
   // For access to Destroy().
   friend class ReferenceCounted<Model>;
 
   virtual void Destroy() = 0;
 };
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_API_MODEL_H_
+#endif  // CLINK_API_MODEL_H_

--- a/include/clink/feature/one_hot_encoder.h
+++ b/include/clink/feature/one_hot_encoder.h
@@ -25,7 +25,7 @@ namespace clink {
 
 // A Model which encodes data into one-hot format.
 class OneHotEncoderModel : public Model {
-public:
+ public:
   // Default constructor.
   OneHotEncoderModel(tfrt::HostContext *host) : allocator_(host->allocator()) {}
 
@@ -45,8 +45,8 @@ public:
   // Loads a OneHotEncoderModel from given path. The path should be a directory
   // containing params and model data saved through
   // org.clink.feature.onehotencoder.ClinkOneHotEnoderModel::save(...).
-  static llvm::Expected<tfrt::RCReference<OneHotEncoderModel>>
-  load(const std::string &path, tfrt::HostContext *host);
+  static llvm::Expected<tfrt::RCReference<OneHotEncoderModel>> load(
+      const std::string &path, tfrt::HostContext *host);
 
   void setDropLast(const bool is_droplast);
 
@@ -56,7 +56,7 @@ public:
   // data string.
   llvm::Error setModelData(const std::string &model_data_str);
 
-private:
+ private:
   void Destroy() override {
     Model::DestroyImpl<OneHotEncoderModel>(this, allocator_);
   }
@@ -76,6 +76,6 @@ private:
   tfrt::HostAllocator *allocator_;
 };
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_FEATURE_ONE_HOT_ENCODER_H_
+#endif  // CLINK_FEATURE_ONE_HOT_ENCODER_H_

--- a/include/clink/kernels/clink_kernels.h
+++ b/include/clink/kernels/clink_kernels.h
@@ -28,6 +28,6 @@ double Square(double x);
 
 void RegisterClinkKernels(tfrt::KernelRegistry *registry);
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_KERNELS_CLINK_KERNELS_H_
+#endif  // CLINK_KERNELS_CLINK_KERNELS_H_

--- a/include/clink/kernels/opdefs/clink_kernels.h
+++ b/include/clink/kernels/opdefs/clink_kernels.h
@@ -28,7 +28,7 @@ namespace clink {
 
 // Dialect for clink operations.
 class ClinkDialect : public Dialect {
-public:
+ public:
   static StringRef getDialectNamespace() { return "clink"; }
   explicit ClinkDialect(MLIRContext *context);
 
@@ -37,9 +37,9 @@ public:
                  mlir::DialectAsmPrinter &printer) const override;
 };
 
-} // namespace clink
+}  // namespace clink
 
 #define GET_OP_CLASSES
 #include "clink/kernels/opdefs/clink_kernels.h.inc"
 
-#endif // CLINK_KERNELS_OPDEFS_CLINK_KERNELS_H_
+#endif  // CLINK_KERNELS_OPDEFS_CLINK_KERNELS_H_

--- a/include/clink/kernels/opdefs/types.h
+++ b/include/clink/kernels/opdefs/types.h
@@ -23,16 +23,16 @@ namespace clink {
 
 class ModelType
     : public mlir::Type::TypeBase<ModelType, mlir::Type, mlir::TypeStorage> {
-public:
+ public:
   using Base::Base;
 };
 
 class VectorType
     : public mlir::Type::TypeBase<VectorType, mlir::Type, mlir::TypeStorage> {
-public:
+ public:
   using Base::Base;
 };
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_FEATURE_OPDEFS_TYPES_H_
+#endif  // CLINK_FEATURE_OPDEFS_TYPES_H_

--- a/include/clink/linalg/sparse_vector.h
+++ b/include/clink/linalg/sparse_vector.h
@@ -23,7 +23,7 @@ namespace clink {
 
 // A sparse vector of double values.
 class SparseVector : public Vector {
-public:
+ public:
   // Constructor for SparseVector.
   // `n` stands for the number of dimensions of the vector.
   explicit SparseVector(const int n) : n_(n) {}
@@ -47,12 +47,12 @@ public:
 
   bool operator==(const SparseVector &other) const;
 
-private:
+ private:
   const int n_;
   llvm::SmallVector<int, 4> indices_;
   llvm::SmallVector<double, 4> values_;
 };
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_LINALG_SPARSE_VECTOR_H_
+#endif  // CLINK_LINALG_SPARSE_VECTOR_H_

--- a/include/clink/linalg/vector.h
+++ b/include/clink/linalg/vector.h
@@ -23,7 +23,7 @@ namespace clink {
 
 // A vector of double values.
 class Vector {
-public:
+ public:
   // Sets the value at a certain index of the vector.
   virtual llvm::Error set(const int index, const double value) = 0;
 
@@ -33,7 +33,7 @@ public:
   // Gets the total number of dimensions of the vector.
   virtual int size() const = 0;
 
-protected:
+ protected:
   // Move operations are supported.
   Vector(Vector &&other) = default;
   Vector &operator=(Vector &&other) = default;
@@ -47,6 +47,6 @@ protected:
   virtual ~Vector() {}
 };
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_LINALG_VECTOR_H_
+#endif  // CLINK_LINALG_VECTOR_H_

--- a/include/clink/utils/clink_runner.h
+++ b/include/clink/utils/clink_runner.h
@@ -27,9 +27,9 @@ namespace clink {
 // This class is a utility class that provides support for users to specify an
 // MLIR function, supply inputs and then have it compiled and run through TFRT.
 class ClinkRunner {
-public:
+ public:
   class Builder {
-  public:
+   public:
     Builder();
 
     // Sets the MLIR function string and returns the object to chain setters.
@@ -70,7 +70,7 @@ public:
     // are not set.
     ClinkRunner Compile();
 
-  private:
+   private:
     std::string mlir_input_;
     std::string fn_name_;
     mlir::MLIRContext *mlir_context_ = nullptr;
@@ -78,10 +78,10 @@ public:
   };
 
   // Runs the MLIR function on TFRT and returns the outputs.
-  llvm::SmallVector<RCReference<AsyncValue>, 4>
-  Run(llvm::ArrayRef<RCReference<AsyncValue>> inputs);
+  llvm::SmallVector<RCReference<AsyncValue>, 4> Run(
+      llvm::ArrayRef<RCReference<AsyncValue>> inputs);
 
-private:
+ private:
   // Use ClinkRunner::Builder to get a ClinkRunner object.
   ClinkRunner(const std::string &fn_name, BefBuffer bef_buffer,
               HostContext *host_context);
@@ -95,6 +95,6 @@ private:
   ExecutionContext execution_context_;
 };
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_UTILS_CLINK_RUNNER_H_
+#endif  // CLINK_UTILS_CLINK_RUNNER_H_

--- a/include/clink/utils/clink_utils.h
+++ b/include/clink/utils/clink_utils.h
@@ -21,9 +21,8 @@ using namespace tfrt;
 
 namespace clink {
 
-std::unique_ptr<tfrt::HostContext>
-CreateHostContext(string_view work_queue_type,
-                  tfrt::HostAllocatorType host_allocator_type);
+std::unique_ptr<tfrt::HostContext> CreateHostContext(
+    string_view work_queue_type, tfrt::HostAllocatorType host_allocator_type);
 
 // Given a directory path, gets the only file in the directory.
 //
@@ -36,6 +35,6 @@ CreateHostContext(string_view work_queue_type,
 // is zero or more than one file in the directory.
 std::string getOnlyFileInDirectory(std::string path);
 
-} // namespace clink
+}  // namespace clink
 
-#endif // CLINK_UTILS_CLINK_UTILS_H_
+#endif  // CLINK_UTILS_CLINK_UTILS_H_

--- a/lib/executor/main.cc
+++ b/lib/executor/main.cc
@@ -17,13 +17,13 @@
 #include "clink/kernels/opdefs/clink_kernels.h"
 #include "clink/utils/clink_runner.h"
 #include "clink/utils/clink_utils.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
 #include "mlir/Support/FileUtilities.h"
 #include "tfrt/basic_kernels/opdefs/basic_kernels.h"
 #include "tfrt/bef_executor_driver/bef_executor_driver.h"
 #include "tfrt/host_context/host_context.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/SourceMgr.h"
 
 using namespace mlir;
 
@@ -31,18 +31,18 @@ static llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional,
                                                 llvm::cl::desc("<input file>"),
                                                 llvm::cl::init("-"));
 
-static llvm::cl::list<std::string> cl_functions( // NOLINT
+static llvm::cl::list<std::string> cl_functions(  // NOLINT
     "functions", llvm::cl::desc("Specify MLIR functions to run"),
     llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated);
 
 // Enable ConcurrentWorkQueue types to be specified on the command line.
-static llvm::cl::opt<std::string> cl_work_queue_type( // NOLINT
+static llvm::cl::opt<std::string> cl_work_queue_type(  // NOLINT
     "work_queue_type",
     llvm::cl::desc("Specify concurrent work queue type (s, mstd, ...):"),
     llvm::cl::init("s"));
 
 // Enable HostAllocator types to be specified on the command line.
-static llvm::cl::opt<tfrt::HostAllocatorType> cl_host_allocator_type( // NOLINT
+static llvm::cl::opt<tfrt::HostAllocatorType> cl_host_allocator_type(  // NOLINT
     "host_allocator_type", llvm::cl::desc("Specify host allocator type:"),
     llvm::cl::values(
         clEnumValN(tfrt::HostAllocatorType::kMalloc, "malloc", "Malloc."),

--- a/lib/feature/one_hot_encoder.cc
+++ b/lib/feature/one_hot_encoder.cc
@@ -23,8 +23,8 @@
 
 namespace clink {
 
-tfrt::AsyncValueRef<SparseVector>
-OneHotEncoderModel::transform(const int value, const int column_index) const {
+tfrt::AsyncValueRef<SparseVector> OneHotEncoderModel::transform(
+    const int value, const int column_index) const {
   if (column_index >= model_data_.featuresizes_size()) {
     return tfrt::MakeErrorAsyncValueRef("Column index out of range.");
   }
@@ -51,8 +51,8 @@ void OneHotEncoderModel::setDropLast(const bool is_droplast) {
 
 bool OneHotEncoderModel::getDropLast() const { return params_.is_droplast; }
 
-llvm::Error
-OneHotEncoderModel::setModelData(const std::string &model_data_str) {
+llvm::Error OneHotEncoderModel::setModelData(
+    const std::string &model_data_str) {
   OneHotEncoderModelDataProto model_data;
 
   if (!model_data.ParseFromString(model_data_str)) {
@@ -71,8 +71,8 @@ OneHotEncoderModel::setModelData(const std::string &model_data_str) {
   return llvm::Error::success();
 }
 
-llvm::Expected<tfrt::RCReference<OneHotEncoderModel>>
-OneHotEncoderModel::load(const std::string &path, tfrt::HostContext *host) {
+llvm::Expected<tfrt::RCReference<OneHotEncoderModel>> OneHotEncoderModel::load(
+    const std::string &path, tfrt::HostContext *host) {
   tfrt::RCReference<OneHotEncoderModel> model =
       TakeRef(host->Construct<OneHotEncoderModel>(host));
 
@@ -105,4 +105,4 @@ OneHotEncoderModel::load(const std::string &path, tfrt::HostContext *host) {
   return model;
 }
 
-} // namespace clink
+}  // namespace clink

--- a/lib/kernels/clink_kernels.cc
+++ b/lib/kernels/clink_kernels.cc
@@ -23,16 +23,16 @@ using namespace tfrt;
 
 namespace clink {
 
-#define CLINK_RETURN_IF_ERROR(KERNEL_ERROR, ERR)                               \
-  do {                                                                         \
-    if (auto err = ERR) {                                                      \
-      llvm::Error unknown = llvm::handleErrors(                                \
-          std::move(err), [&](const llvm::StringError &err) {                  \
-            KERNEL_ERROR.ReportError(err.getMessage());                        \
-          });                                                                  \
-      assert(!unknown && "Unknown error type");                                \
-      return;                                                                  \
-    }                                                                          \
+#define CLINK_RETURN_IF_ERROR(KERNEL_ERROR, ERR)              \
+  do {                                                        \
+    if (auto err = ERR) {                                     \
+      llvm::Error unknown = llvm::handleErrors(               \
+          std::move(err), [&](const llvm::StringError &err) { \
+            KERNEL_ERROR.ReportError(err.getMessage());       \
+          });                                                 \
+      assert(!unknown && "Unknown error type");               \
+      return;                                                 \
+    }                                                         \
   } while (0)
 
 AsyncValueRef<double> SquareAdd(Argument<double> x, Argument<double> y,
@@ -73,10 +73,9 @@ void OneHotEncoderLoad(Argument<std::string> path,
   result_model.Emplace(model.get());
 }
 
-AsyncValueRef<SparseVector>
-OneHotEncoderTransform(RCReference<OneHotEncoderModel> model,
-                       Argument<int> value, Argument<int> column_index,
-                       const ExecutionContext &exec_ctx) {
+AsyncValueRef<SparseVector> OneHotEncoderTransform(
+    RCReference<OneHotEncoderModel> model, Argument<int> value,
+    Argument<int> column_index, const ExecutionContext &exec_ctx) {
   return model->transform(value.get(), column_index.get());
 }
 
@@ -93,4 +92,4 @@ void RegisterClinkKernels(tfrt::KernelRegistry *registry) {
                       TFRT_KERNEL(OneHotEncoderTransform));
 }
 
-} // namespace clink
+}  // namespace clink

--- a/lib/kernels/opdefs/clink_kernels.cc
+++ b/lib/kernels/opdefs/clink_kernels.cc
@@ -41,13 +41,10 @@ ClinkDialect::ClinkDialect(MLIRContext *context)
 
 mlir::Type ClinkDialect::parseType(mlir::DialectAsmParser &parser) const {
   llvm::StringRef spec = parser.getFullSymbolSpec();
-  if (spec == "model")
-    return ModelType::get(getContext());
-  if (spec == "vector")
-    return VectorType::get(getContext());
+  if (spec == "model") return ModelType::get(getContext());
+  if (spec == "vector") return VectorType::get(getContext());
 
-  if (auto type = mlir::Dialect::parseType(parser))
-    return type;
+  if (auto type = mlir::Dialect::parseType(parser)) return type;
 
   mlir::Location loc = parser.getEncodedSourceLoc(parser.getNameLoc());
   mlir::emitError(loc) << "unknown data type " << spec;
@@ -69,7 +66,7 @@ void ClinkDialect::printType(mlir::Type type,
   llvm_unreachable("unknown data type");
 }
 
-} // namespace clink
+}  // namespace clink
 
 //===----------------------------------------------------------------------===//
 // TableGen'd op method definitions

--- a/lib/kernels/static_registration.cc
+++ b/lib/kernels/static_registration.cc
@@ -23,4 +23,4 @@ namespace clink {
 
 TFRT_STATIC_KERNEL_REGISTRATION(RegisterClinkKernels);
 
-} // namespace clink
+}  // namespace clink

--- a/lib/linalg/sparse_vector.cc
+++ b/lib/linalg/sparse_vector.cc
@@ -62,4 +62,4 @@ bool SparseVector::operator==(const SparseVector &other) const {
   return true;
 }
 
-} // namespace clink
+}  // namespace clink

--- a/lib/utils/clink_runner.cc
+++ b/lib/utils/clink_runner.cc
@@ -42,7 +42,9 @@ ClinkRunner ClinkRunner::Builder::Compile() {
 
 ClinkRunner::ClinkRunner(const std::string &fn_name, BefBuffer bef_buffer,
                          HostContext *host_context)
-    : fn_name_(fn_name), bef_buffer_(bef_buffer), host_context_(host_context),
+    : fn_name_(fn_name),
+      bef_buffer_(bef_buffer),
+      host_context_(host_context),
       execution_context_(
           *tfrt::RequestContextBuilder(host_context_, resource_context_.get())
                .build()) {
@@ -52,8 +54,8 @@ ClinkRunner::ClinkRunner(const std::string &fn_name, BefBuffer bef_buffer,
   func_ = bef_file_->GetFunction(fn_name_);
 }
 
-llvm::SmallVector<RCReference<AsyncValue>, 4>
-ClinkRunner::Run(ArrayRef<RCReference<AsyncValue>> inputs) {
+llvm::SmallVector<RCReference<AsyncValue>, 4> ClinkRunner::Run(
+    ArrayRef<RCReference<AsyncValue>> inputs) {
   assert((func_->num_arguments() == inputs.size()) &&
          "Incorrect number of arguments set.");
 
@@ -68,4 +70,4 @@ ClinkRunner::Run(ArrayRef<RCReference<AsyncValue>> inputs) {
   return std::move(results);
 }
 
-} // namespace clink
+}  // namespace clink

--- a/lib/utils/clink_utils.cc
+++ b/lib/utils/clink_utils.cc
@@ -15,8 +15,9 @@
 #include "clink/utils/clink_utils.h"
 
 #include <dirent.h>
-#include <string>
 #include <sys/stat.h>
+
+#include <string>
 
 #include "tfrt/host_context/concurrent_work_queue.h"
 #include "tfrt/host_context/host_context.h"
@@ -24,9 +25,8 @@
 
 namespace clink {
 
-std::unique_ptr<HostContext>
-CreateHostContext(string_view work_queue_type,
-                  tfrt::HostAllocatorType host_allocator_type) {
+std::unique_ptr<HostContext> CreateHostContext(
+    string_view work_queue_type, tfrt::HostAllocatorType host_allocator_type) {
   auto decoded_diagnostic_handler = [&](const DecodedDiagnostic &diag) {
     TFRT_LOG(FATAL) << "Encountered error while executing, aborting: "
                     << diag.message;
@@ -36,23 +36,23 @@ CreateHostContext(string_view work_queue_type,
 
   std::unique_ptr<HostAllocator> host_allocator;
   switch (host_allocator_type) {
-  case HostAllocatorType::kMalloc:
-    host_allocator = CreateMallocAllocator();
-    llvm::outs() << "Choosing malloc.\n";
-    break;
-  case HostAllocatorType::kTestFixedSizeMalloc:
-    host_allocator = tfrt::CreateFixedSizeAllocator();
-    llvm::outs() << "Choosing fixed size malloc.\n";
-    break;
-  case HostAllocatorType::kProfiledMalloc:
-    host_allocator = CreateMallocAllocator();
-    host_allocator = CreateProfiledAllocator(std::move(host_allocator));
-    llvm::outs() << "Choosing profiled allocator based on malloc.\n";
-    break;
-  case HostAllocatorType::kLeakCheckMalloc:
-    host_allocator = CreateMallocAllocator();
-    host_allocator = CreateLeakCheckAllocator(std::move(host_allocator));
-    llvm::outs() << "Choosing memory leak check allocator.\n";
+    case HostAllocatorType::kMalloc:
+      host_allocator = CreateMallocAllocator();
+      llvm::outs() << "Choosing malloc.\n";
+      break;
+    case HostAllocatorType::kTestFixedSizeMalloc:
+      host_allocator = tfrt::CreateFixedSizeAllocator();
+      llvm::outs() << "Choosing fixed size malloc.\n";
+      break;
+    case HostAllocatorType::kProfiledMalloc:
+      host_allocator = CreateMallocAllocator();
+      host_allocator = CreateProfiledAllocator(std::move(host_allocator));
+      llvm::outs() << "Choosing profiled allocator based on malloc.\n";
+      break;
+    case HostAllocatorType::kLeakCheckMalloc:
+      host_allocator = CreateMallocAllocator();
+      host_allocator = CreateLeakCheckAllocator(std::move(host_allocator));
+      llvm::outs() << "Choosing memory leak check allocator.\n";
   }
   llvm::outs().flush();
 
@@ -74,8 +74,7 @@ std::string getOnlyFileInDirectory(std::string path) {
   }
   while ((entry = readdir(dir)) != NULL) {
     const std::string full_file_name = path + "/" + entry->d_name;
-    if (stat(full_file_name.c_str(), &st) == -1)
-      continue;
+    if (stat(full_file_name.c_str(), &st) == -1) continue;
     bool is_directory = (st.st_mode & S_IFDIR) != 0;
     if (!is_directory) {
       if (result != "") {
@@ -88,4 +87,4 @@ std::string getOnlyFileInDirectory(std::string path) {
   return result;
 }
 
-} // namespace clink
+}  // namespace clink

--- a/tools/format-code.sh
+++ b/tools/format-code.sh
@@ -19,19 +19,33 @@
 
 set -e
 
+version_array=(
+    "clang-format"  "11.1.0"    "clang-format --version | cut -d\" \" -f3"
+    "bazel"         "4.0.0"     "bazel --version | cut -d\" \" -f2"
+    "mvn"           "3.1.0"     "mvn --version | head -n1 | cut -d\" \" -f3"
+)
+
 # Checks whether required tools have been installed
-for cmd in clang-format mvn
-do
+for ((i = 0; i < ${#version_array[@]}; i += 3)); do
+    cmd=${version_array[$i]}
     if ! command -v $cmd &> /dev/null
     then
         echo "$cmd: command not found"
-        exit
+        exit 1
+    fi
+    expected_version=${version_array[$i+1]}
+    actual_version=`eval "${version_array[$i+2]}"`
+    unsorted_versions="${expected_version}\n${actual_version}\n"
+    sorted_versions=`printf ${unsorted_versions} | sort -V`
+    unsorted_versions=`printf ${unsorted_versions}`
+    if [ "${unsorted_versions}" != "${sorted_versions}" ]; then
+        echo "$cmd $expected_version or a higher version is required, but found $actual_version"
+        exit 1
     fi
 done
 
-# TODO: change clang-format style to google
 # Formats C++ codes
-find . \( -name "*.cc" -or -name "*.h" \) -not -path "./tfrt/*" -exec clang-format -i -style=llvm {} \;
+find . \( -name "*.cc" -or -name "*.h" \) -not -path "./tfrt/*" -exec clang-format -i {} \;
 
 # Formats Java codes
 mvn -f java-lib spotless:apply


### PR DESCRIPTION
- Add Action to check whether code is formatted
- Check required tools's version in ./tools/format-code.sh
- Change clang-format to use Google style
- Move clang-format style config from cmd to .clang-format file
- Apply newly configured clang-format to all codes

This PR resolves #13 and #16.