### PR TITLE
Pre-build TFRT Bazel Targets in Docker images

### DIFF
--- a/docker/Dockerfile_centos_77
+++ b/docker/Dockerfile_centos_77
@@ -21,7 +21,7 @@ FROM centos:centos7.7.1908 as base
 RUN curl https://copr.fedorainfracloud.org/coprs/vbatts/bazel/repo/epel-7/vbatts-bazel-epel-7.repo > /etc/yum.repos.d/vbatts-bazel-epel-7.repo && \
     echo "source /opt/rh/devtoolset-8/enable" >> ~/.bashrc
 
-RUN yum update -y && yum install -y bazel4 centos-release-scl epel-release wget gcc
+RUN yum update -y && yum install -y bazel4 centos-release-scl epel-release wget gcc git
 
 RUN yum update -y && yum install -y cmake3 devtoolset-8
 
@@ -35,3 +35,9 @@ RUN mkdir /llvm-project-11.1.0.src/build && \
     make install -j 8 && \
     rm -rf /llvm-project-11.1.0.src
 
+RUN git clone --depth 1 https://github.com/flink-extended/clink.git /tmp/clink && \
+    cd /tmp/clink && \
+    git submodule update --init --recursive && \
+    bazel build --disk_cache=~/.cache/bazel @tf_runtime//tools:bef_executor_lite && \
+    bazel build --disk_cache=~/.cache/bazel @tf_runtime//tools:tfrt_translate && \
+    rm -rf /tmp/clink

--- a/docker/Dockerfile_ubuntu_1604
+++ b/docker/Dockerfile_ubuntu_1604
@@ -27,8 +27,15 @@ RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/ap
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
     apt-get update && \
-    apt-get install -y --allow-unauthenticated --fix-missing bazel clang-11 gcc-8 g++-8 openjdk-8-jdk && \
+    apt-get install -y --allow-unauthenticated --fix-missing bazel clang-11 gcc-8 g++-8 openjdk-8-jdk git && \
     rm -rf /var/lib/apt/lists/* 
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 11 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 11
+
+RUN git clone --depth 1 https://github.com/flink-extended/clink.git /tmp/clink && \
+    cd /tmp/clink && \
+    git submodule update --init --recursive && \
+    bazel build --disk_cache=~/.cache/bazel @tf_runtime//tools:bef_executor_lite && \
+    bazel build --disk_cache=~/.cache/bazel @tf_runtime//tools:tfrt_translate && \
+    rm -rf /tmp/clink


### PR DESCRIPTION
This PR updates Dockerfiles to add prebuilt TFRT Bazel targets in the images.

Bazel command line interface provides a `disk_cache` configuration property. Bazel builds with the same `disk_cache` property can share Bazel targets and avoid rebuilding them. This PR is achieved based on this functionality.

This PR saves the prebuilt TFRT results in the default cache directory that Bazel builds would seek from, so there is no need to modify commands provided in README in order to utilize this feature.

This PR resolves #17 .